### PR TITLE
test_string variable needs to be converted to string from bytes to be compared to ignore list

### DIFF
--- a/pantastic/pantastic.py
+++ b/pantastic/pantastic.py
@@ -155,7 +155,7 @@ class Pantastic:
                                 if len(test_string) < self.minimum_digits and len(number_groups[test_index].group(0)) < 4:  # All groupings below n digits are more than 4 digits in length
                                     break
 
-                                if len(test_string) >= self.minimum_digits and test_string not in self.ignore_cards:  # Minimum credit card length
+                                if len(test_string) >= self.minimum_digits and test_string.decode("utf-8") not in self.ignore_cards:  # Minimum credit card length
                                     card = Card.fromCardNumber(test_string.decode("utf-8"))
                                     if not self.include_deprecated and card.deprecated:
                                         break


### PR DESCRIPTION
Currently, the card number in the test_string varaible is built as a byte variable and then compared to the ignore list which is an array of strings. This always fails since its comparing two different data types.

This converts the test_string variable that is being compared to the ignore list to a string before comparison to work properly.